### PR TITLE
Disable PX4 QGroundControl Cache Loading

### DIFF
--- a/build_and_create_linux_appimage.sh
+++ b/build_and_create_linux_appimage.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -e
+
+docker build --file ./deploy/docker/Dockerfile-build-linux -t qgc-ubuntu-docker .
+
+if [ -d build ]; then
+	rm -r build
+fi
+mkdir build
+docker run --rm -v ${PWD}:/project/source -v ${PWD}/build:/project/build qgc-ubuntu-docker
+./deploy/create_linux_appimage.sh . build/staging

--- a/src/FactSystem/ParameterManager.cc
+++ b/src/FactSystem/ParameterManager.cc
@@ -254,13 +254,14 @@ void ParameterManager::_handleParamValue(int componentId, QString parameterName,
     }
 #endif
 
-    if (_vehicle->px4Firmware() && parameterName == "_HASH_CHECK") {
-        if (!_initialLoadComplete && !_logReplay) {
-            /* we received a cache hash, potentially load from cache */
-            _tryCacheHashLoad(_vehicle->id(), componentId, parameterValue);
-        }
-        return;
-    }
+    // Disable cache load from QGC, as PX4 Parameters can be different from QGC
+    // if (_vehicle->px4Firmware() && parameterName == "_HASH_CHECK") {
+    //     if (!_initialLoadComplete && !_logReplay) {
+    //         /* we received a cache hash, potentially load from cache */
+    //         _tryCacheHashLoad(_vehicle->id(), componentId, parameterValue);
+    //     }
+    //     return;
+    // }
 
     // Used to debug cache crc misses (turn on ParameterManagerDebugCacheFailureLog)
     if (!_initialLoadComplete && !_logReplay && _debugCacheCRC.contains(componentId) && _debugCacheCRC[componentId]) {


### PR DESCRIPTION
This PR disables QGroundControl cache loading, commenting out the line that tries to load cache hash.

Tested on a Pixhawk 4 flight controller, with the output as shown below (Connected to the Pixhawk 4 Flight Controller without any issue):

![Screenshot from 2024-12-09 15-52-23](https://github.com/user-attachments/assets/c6ffe5de-2a3d-4b09-a15c-e142717010d1)

In addition, added a script to simplify building the AppImage.