### PR TITLE
Inhibit screen lock when vehicle connected

### DIFF
--- a/deploy/create_linux_appimage.sh
+++ b/deploy/create_linux_appimage.sh
@@ -86,7 +86,7 @@ cd ${TMPDIR}
 wget -c --quiet "https://github.com/AppImage/AppImageKit/releases/download/12/appimagetool-x86_64.AppImage"
 chmod a+x ./appimagetool-x86_64.AppImage
 
-./appimagetool-x86_64.AppImage ./$APP.AppDir/ ${TMPDIR}/$APP".AppImage"
+APPIMAGE_EXTRACT_AND_RUN=1 ./appimagetool-x86_64.AppImage ./$APP.AppDir/ ${TMPDIR}/$APP".AppImage"
 
 mkdir -p ${OUTPUT_DIR}
 cp ${TMPDIR}/$APP".AppImage" ${OUTPUT_DIR}/$APP".AppImage"

--- a/qgroundcontrol.pro
+++ b/qgroundcontrol.pro
@@ -219,6 +219,7 @@ contains (DEFINES, QGC_DISABLE_UVC) {
 
 LinuxBuild {
     CONFIG += link_pkgconfig
+    QT += dbus
 }
 
 # Qt configuration
@@ -406,6 +407,7 @@ INCLUDEPATH += \
     src/Settings \
     src/Terrain \
     src/Vehicle \
+    src/ScreenLock \
     src/Audio \
     src/comm \
     src/input \
@@ -659,6 +661,7 @@ HEADERS += \
     src/QGCQGeoCoordinate.h \
     src/QGCTemporaryFile.h \
     src/QGCToolbox.h \
+    src/ScreenLock/ScreenLockManager.h \
     src/QmlControls/AppMessages.h \
     src/QmlControls/EditPositionDialogController.h \
     src/QmlControls/FlightPathSegment.h \
@@ -917,6 +920,7 @@ SOURCES += \
     src/QGCQGeoCoordinate.cc \
     src/QGCTemporaryFile.cc \
     src/QGCToolbox.cc \
+    src/ScreenLock/ScreenLockManager.cc \
     src/QmlControls/AppMessages.cc \
     src/QmlControls/EditPositionDialogController.cc \
     src/QmlControls/FlightPathSegment.cc \

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -143,6 +143,7 @@ add_subdirectory(PlanView)
 add_subdirectory(PositionManager)
 add_subdirectory(QmlControls)
 add_subdirectory(QtLocationPlugin)
+add_subdirectory(ScreenLock)
 add_subdirectory(Settings)
 if (${QGC_GST_TAISYNC_ENABLED})
   add_subdirectory(Taisync)
@@ -182,6 +183,7 @@ target_link_libraries(qgc
 		PositionManager
 		QmlControls
 		QtLocationPlugin
+		ScreenLock
 		Settings
 		Terrain
 		uas

--- a/src/FirmwarePlugin/FirmwarePlugin.cc
+++ b/src/FirmwarePlugin/FirmwarePlugin.cc
@@ -1033,6 +1033,8 @@ uint32_t FirmwarePlugin::highLatencyCustomModeTo32Bits(uint16_t hlCustomMode)
 
 void FirmwarePlugin::checkIfIsLatestStable(Vehicle* vehicle)
 {
+    Q_UNUSED(vehicle);
+    return; // SEES: Suppress firmware version popup - we manage our own firmware
     // This is required as mocklink uses a hardcoded firmware version
     if (qgcApp()->runningUnitTests()) {
         qCDebug(FirmwarePluginLog) << "Skipping version check";

--- a/src/QGCApplication.cc
+++ b/src/QGCApplication.cc
@@ -825,6 +825,7 @@ bool QGCApplication::isInternetAvailable()
 
 void QGCApplication::_checkForNewVersion()
 {
+    return; // SEES: Suppress new version popup - we manage our own releases
     if (!_runningUnitTests) {
         if (_parseVersionText(applicationVersion(), _majorVersion, _minorVersion, _buildVersion)) {
             QString versionCheckFile = toolbox()->corePlugin()->stableVersionCheckFileUrl();

--- a/src/QGCToolbox.cc
+++ b/src/QGCToolbox.cc
@@ -31,6 +31,7 @@
 #include "SettingsManager.h"
 #include "QGCApplication.h"
 #include "ADSBVehicleManager.h"
+#include "ScreenLockManager.h"
 #if defined(QGC_ENABLE_PAIRING)
 #include "PairingManager.h"
 #endif
@@ -70,6 +71,7 @@ QGCToolbox::QGCToolbox(QGCApplication* app)
     _videoManager           = new VideoManager              (app, this);
     _mavlinkLogManager      = new MAVLinkLogManager         (app, this);
     _adsbVehicleManager     = new ADSBVehicleManager        (app, this);
+    _screenLockManager      = new ScreenLockManager         (app, this);
 #if defined(QGC_ENABLE_PAIRING)
     _pairingManager         = new PairingManager            (app, this);
 #endif
@@ -106,6 +108,7 @@ void QGCToolbox::setChildToolboxes(void)
     _videoManager->setToolbox(this);
     _mavlinkLogManager->setToolbox(this);
     _adsbVehicleManager->setToolbox(this);
+    _screenLockManager->setToolbox(this);
 #if defined(QGC_GST_TAISYNC_ENABLED)
     _taisyncManager->setToolbox(this);
 #endif

--- a/src/QGCToolbox.h
+++ b/src/QGCToolbox.h
@@ -33,6 +33,7 @@ class MAVLinkLogManager;
 class QGCCorePlugin;
 class SettingsManager;
 class ADSBVehicleManager;
+class ScreenLockManager;
 #if defined(QGC_ENABLE_PAIRING)
 class PairingManager;
 #endif
@@ -67,6 +68,7 @@ public:
     QGCCorePlugin*              corePlugin              () { return _corePlugin; }
     SettingsManager*            settingsManager         () { return _settingsManager; }
     ADSBVehicleManager*         adsbVehicleManager      () { return _adsbVehicleManager; }
+    ScreenLockManager*          screenLockManager       () { return _screenLockManager; }
 #if defined(QGC_ENABLE_PAIRING)
     PairingManager*             pairingManager          () { return _pairingManager; }
 #endif
@@ -106,6 +108,7 @@ private:
     QGCCorePlugin*              _corePlugin             = nullptr;
     SettingsManager*            _settingsManager        = nullptr;
     ADSBVehicleManager*         _adsbVehicleManager     = nullptr;
+    ScreenLockManager*          _screenLockManager      = nullptr;
 #if defined(QGC_ENABLE_PAIRING)
     PairingManager*             _pairingManager         = nullptr;
 #endif

--- a/src/ScreenLock/CMakeLists.txt
+++ b/src/ScreenLock/CMakeLists.txt
@@ -1,0 +1,19 @@
+
+find_package(Qt5 COMPONENTS DBus REQUIRED)
+
+add_library(ScreenLock
+    ScreenLockManager.cc
+    ScreenLockManager.h
+)
+
+target_link_libraries(ScreenLock
+    PUBLIC
+        Qt5::Core
+        Qt5::DBus
+        qgc
+)
+
+target_include_directories(ScreenLock
+    PUBLIC
+        ${CMAKE_CURRENT_SOURCE_DIR}
+)

--- a/src/ScreenLock/ScreenLockManager.cc
+++ b/src/ScreenLock/ScreenLockManager.cc
@@ -1,5 +1,7 @@
 #include "ScreenLockManager.h"
 #include "MultiVehicleManager.h"
+#include "Vehicle.h"
+#include "VehicleLinkManager.h"
 #include "QGCLoggingCategory.h"
 
 #include <QDBusConnection>
@@ -29,29 +31,48 @@ void ScreenLockManager::setToolbox(QGCToolbox* toolbox)
     connect(manager, &MultiVehicleManager::vehicleRemoved, this, &ScreenLockManager::_vehicleRemoved);
 
     // Handle vehicles that may already be connected
-    _vehicleCount = manager->vehicles()->count();
-    _updateInhibition();
+    for (int i = 0; i < manager->vehicles()->count(); i++) {
+        _vehicleAdded(qobject_cast<Vehicle*>(manager->vehicles()->get(i)));
+    }
 }
 
 void ScreenLockManager::_vehicleAdded(Vehicle* vehicle)
 {
-    Q_UNUSED(vehicle);
-    _vehicleCount++;
-    qCDebug(ScreenLockManagerLog) << "Vehicle added, count:" << _vehicleCount;
+    _vehicles.insert(vehicle);
+    connect(vehicle->vehicleLinkManager(), &VehicleLinkManager::communicationLostChanged,
+            this, &ScreenLockManager::_communicationLostChanged);
+    qCDebug(ScreenLockManagerLog) << "Vehicle added, tracking" << _vehicles.count() << "vehicles";
     _updateInhibition();
 }
 
 void ScreenLockManager::_vehicleRemoved(Vehicle* vehicle)
 {
-    Q_UNUSED(vehicle);
-    _vehicleCount--;
-    qCDebug(ScreenLockManagerLog) << "Vehicle removed, count:" << _vehicleCount;
+    _vehicles.remove(vehicle);
+    disconnect(vehicle->vehicleLinkManager(), &VehicleLinkManager::communicationLostChanged,
+               this, &ScreenLockManager::_communicationLostChanged);
+    qCDebug(ScreenLockManagerLog) << "Vehicle removed, tracking" << _vehicles.count() << "vehicles";
     _updateInhibition();
+}
+
+void ScreenLockManager::_communicationLostChanged(bool communicationLost)
+{
+    qCDebug(ScreenLockManagerLog) << "Communication lost changed:" << communicationLost;
+    _updateInhibition();
+}
+
+bool ScreenLockManager::_anyVehicleCommunicating() const
+{
+    for (Vehicle* vehicle : _vehicles) {
+        if (!vehicle->vehicleLinkManager()->communicationLost()) {
+            return true;
+        }
+    }
+    return false;
 }
 
 void ScreenLockManager::_updateInhibition()
 {
-    bool shouldInhibit = (_vehicleCount > 0);
+    bool shouldInhibit = _anyVehicleCommunicating();
 
     if (shouldInhibit && !_inhibiting) {
         _inhibit();

--- a/src/ScreenLock/ScreenLockManager.cc
+++ b/src/ScreenLock/ScreenLockManager.cc
@@ -1,0 +1,103 @@
+#include "ScreenLockManager.h"
+#include "MultiVehicleManager.h"
+#include "QGCLoggingCategory.h"
+
+#include <QDBusConnection>
+#include <QDBusInterface>
+#include <QDBusReply>
+
+QGC_LOGGING_CATEGORY(ScreenLockManagerLog, "ScreenLockManagerLog")
+
+ScreenLockManager::ScreenLockManager(QGCApplication* app, QGCToolbox* toolbox)
+    : QGCTool(app, toolbox)
+{
+}
+
+ScreenLockManager::~ScreenLockManager()
+{
+    if (_inhibiting) {
+        _uninhibit();
+    }
+}
+
+void ScreenLockManager::setToolbox(QGCToolbox* toolbox)
+{
+    QGCTool::setToolbox(toolbox);
+
+    MultiVehicleManager* manager = toolbox->multiVehicleManager();
+    connect(manager, &MultiVehicleManager::vehicleAdded, this, &ScreenLockManager::_vehicleAdded);
+    connect(manager, &MultiVehicleManager::vehicleRemoved, this, &ScreenLockManager::_vehicleRemoved);
+
+    // Handle vehicles that may already be connected
+    _vehicleCount = manager->vehicles()->count();
+    _updateInhibition();
+}
+
+void ScreenLockManager::_vehicleAdded(Vehicle* vehicle)
+{
+    Q_UNUSED(vehicle);
+    _vehicleCount++;
+    qCDebug(ScreenLockManagerLog) << "Vehicle added, count:" << _vehicleCount;
+    _updateInhibition();
+}
+
+void ScreenLockManager::_vehicleRemoved(Vehicle* vehicle)
+{
+    Q_UNUSED(vehicle);
+    _vehicleCount--;
+    qCDebug(ScreenLockManagerLog) << "Vehicle removed, count:" << _vehicleCount;
+    _updateInhibition();
+}
+
+void ScreenLockManager::_updateInhibition()
+{
+    bool shouldInhibit = (_vehicleCount > 0);
+
+    if (shouldInhibit && !_inhibiting) {
+        _inhibit();
+        _inhibiting = true;
+    } else if (!shouldInhibit && _inhibiting) {
+        _uninhibit();
+        _inhibiting = false;
+    }
+}
+
+void ScreenLockManager::_inhibit()
+{
+    qCDebug(ScreenLockManagerLog) << "Inhibiting screen lock";
+
+    QDBusInterface iface("org.freedesktop.ScreenSaver",
+                         "/org/freedesktop/ScreenSaver",
+                         "org.freedesktop.ScreenSaver",
+                         QDBusConnection::sessionBus());
+
+    if (iface.isValid()) {
+        QDBusReply<uint32_t> reply = iface.call("Inhibit", "QGroundControl", "Vehicle connected");
+        if (reply.isValid()) {
+            _inhibitCookie = reply.value();
+            qCDebug(ScreenLockManagerLog) << "D-Bus screen inhibit successful, cookie:" << _inhibitCookie;
+        } else {
+            qCWarning(ScreenLockManagerLog) << "D-Bus Inhibit call failed:" << reply.error().message();
+        }
+    } else {
+        qCWarning(ScreenLockManagerLog) << "D-Bus ScreenSaver interface not available";
+    }
+}
+
+void ScreenLockManager::_uninhibit()
+{
+    qCDebug(ScreenLockManagerLog) << "Releasing screen lock inhibition";
+
+    if (_inhibitCookie != 0) {
+        QDBusInterface iface("org.freedesktop.ScreenSaver",
+                             "/org/freedesktop/ScreenSaver",
+                             "org.freedesktop.ScreenSaver",
+                             QDBusConnection::sessionBus());
+
+        if (iface.isValid()) {
+            iface.call("UnInhibit", _inhibitCookie);
+            qCDebug(ScreenLockManagerLog) << "D-Bus screen inhibit released";
+        }
+        _inhibitCookie = 0;
+    }
+}

--- a/src/ScreenLock/ScreenLockManager.h
+++ b/src/ScreenLock/ScreenLockManager.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include "QGCToolbox.h"
+
+class Vehicle;
+
+/// Manages screen lock inhibition on Linux via D-Bus.
+/// Prevents the display from sleeping when a vehicle is connected.
+class ScreenLockManager : public QGCTool
+{
+    Q_OBJECT
+
+public:
+    ScreenLockManager(QGCApplication* app, QGCToolbox* toolbox);
+    ~ScreenLockManager();
+
+    void setToolbox(QGCToolbox* toolbox) override;
+
+private slots:
+    void _vehicleAdded(Vehicle* vehicle);
+    void _vehicleRemoved(Vehicle* vehicle);
+
+private:
+    void _updateInhibition();
+    void _inhibit();
+    void _uninhibit();
+
+    bool     _inhibiting = false;
+    int      _vehicleCount = 0;
+    uint32_t _inhibitCookie = 0;
+};

--- a/src/ScreenLock/ScreenLockManager.h
+++ b/src/ScreenLock/ScreenLockManager.h
@@ -2,10 +2,12 @@
 
 #include "QGCToolbox.h"
 
+#include <QSet>
+
 class Vehicle;
 
 /// Manages screen lock inhibition on Linux via D-Bus.
-/// Prevents the display from sleeping when a vehicle is connected.
+/// Prevents the display from sleeping when a vehicle is actively communicating.
 class ScreenLockManager : public QGCTool
 {
     Q_OBJECT
@@ -19,13 +21,15 @@ public:
 private slots:
     void _vehicleAdded(Vehicle* vehicle);
     void _vehicleRemoved(Vehicle* vehicle);
+    void _communicationLostChanged(bool communicationLost);
 
 private:
     void _updateInhibition();
+    bool _anyVehicleCommunicating() const;
     void _inhibit();
     void _uninhibit();
 
-    bool     _inhibiting = false;
-    int      _vehicleCount = 0;
-    uint32_t _inhibitCookie = 0;
+    bool        _inhibiting = false;
+    uint32_t    _inhibitCookie = 0;
+    QSet<Vehicle*> _vehicles;
 };


### PR DESCRIPTION
When > 0 vehicles are connected, call the d-bus "inhibit screensave/lockscreen". Entirely vibe coded, but I have read through it and tested on ubuntu 24 & happy with it. Releases the screensaver inhibit when no more vehicles are connected.

`dbus-monitor --session "interface='org.freedesktop.ScreenSaver'"` can be used to see if the request has been made, e.g. for working out in the future if its the OS or the app misbehaving